### PR TITLE
[BugID: 16197] Add support for updating supplemental tables

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -102,6 +102,23 @@ You can also parse the response CSV file from Responsys. This is useful to find 
     user.save
   end
 
+=== Code Generation
+
+Some of the code is auto-generated.
+
+    /path/to/gems/soap4r-1.5.8/bin/wsdl2ruby.rb --wsdl https://ws5.responsys.net/webservices/wsdl/ResponsysWS_Level1.wsdl --type client
+
+generates the following files in /lib/stub: ResponsysWSServiceClient.rb, default.rb, defaultDriver.rb
+
+=== Testing
+
+First, set up test/config.yml for the live integration test.  See the example at test/config.yml.sample
+
+
+Then you can run tests with:
+
+    rake
+
 == IMPORTANT 
 
 This gem is still in development mode. It is not hosted on rubygems.org yet.

--- a/Rakefile
+++ b/Rakefile
@@ -5,9 +5,9 @@ require 'echoe'
 
 Echoe.new('sundawg_responsys_client', '0.0.1') do |p|
   p.description    = "Ruby SOAP Client For Responsys API"
-  p.url            = "http://github.com/SunDawg/responsys_client"
-  p.author         = "Christopher Sun"
-  p.email          = "christopher.sun@gmail.com"
+  p.url            = "http://github.com/animoto/responsys_client"
+  p.author         = ["Christopher Sun", "Jeff Jolma"]
+  p.email          = ["christopher.sun@gmail.com", "jeff@animoto.com"]
   p.ignore_pattern = ["tmp/*", "script/*"]
   p.development_dependencies = ['mocha >=0.9.12']
   p.runtime_dependencies = ['soap4r >=1.5.8', 'fastercsv >=1.5.4']

--- a/lib/member.rb
+++ b/lib/member.rb
@@ -117,11 +117,6 @@ module SunDawg
           end
           extension_fields.flatten!
 
-          # Create the primary profile CSV
-          user_attributes = @@fields.reject { |i| extension_fields.include?(i) }
-          user_attributes = [:customer_id] + user_attributes unless user_attributes.include?(:customer_id)
-          build_csv_file(members, "#{root_directory}/member#{options[:file_token]}.csv", user_attributes, options[:headers], options[:access]) 
-
           # Create the profile extension CSVs
           @@extension_fields.each_pair do |file_name, attributes|
             attributes = [:customer_id] + attributes unless attributes.include?(:customer_id)

--- a/lib/responsys_client.rb
+++ b/lib/responsys_client.rb
@@ -92,6 +92,32 @@ module SunDawg
         end
       end
 
+      def save_supplemental_table_with_pk(folder_name, list_name, members)
+        with_session do
+          table = InteractObject.new
+          table.folderName = folder_name
+          table.objectName = list_name
+
+          record_data = RecordData.new
+          record_data.fieldNames = members.first.keys.map { |f| f.to_s.upcase }
+          record_data.records = []
+
+          members.each do |member|
+            record = []
+            record_data.fieldNames.each do |field|
+              record << member[field]
+            end
+            record_data.records << record
+          end
+
+          insert_on_match = true
+          update_on_match = UpdateOnMatch::REPLACE_ALL
+          merge = MergeTableRecordsWithPK.new(table, record_data, insert_on_match, update_on_match)
+          @responsys_client.mergeTableRecordsWithPK(merge)
+        end
+      end
+
+
       def save_members(folder_name, list_name, members, attributes = SunDawg::Responsys::Member.fields)
         raise MethodsNotSupportedError unless SunDawg::Responsys::Member.fields.include?(:email_address) && SunDawg::Responsys::Member.fields.include?(:email_permission_status) && SunDawg::Responsys::Member.fields.include?(:customer_id)
         raise TooManyMembersError if members.size > MAX_MEMBERS

--- a/lib/stub/default.rb
+++ b/lib/stub/default.rb
@@ -1679,6 +1679,41 @@ module SunDawg
       end
     end
 
+    # {urn:ws.rsys.com}mergeTableRecordsWithPK
+    class MergeTableRecordsWithPK
+      @@schema_type = "mergeTableRecordsWithPK"
+      @@schema_ns = "urn:ws.rsys.com"
+      @@schema_qualified = "true"
+      @@schema_element = [["table", "InteractObject"], ["recordData", "RecordData"], ["insertOnNoMatch", "SOAP::SOAPBoolean"], ["updateOnMatch", "SOAP::SOAPString"]]
+
+      attr_accessor :table
+      attr_accessor :recordData
+      attr_accessor :insertOnNoMatch
+      attr_accessor :updateOnMatch
+
+      def initialize(table = nil, recordData = nil, insertOnNoMatch = nil, updateOnMatch = nil)
+        @table = table
+        @recordData = recordData
+        @insertOnNoMatch = insertOnNoMatch
+        @updateOnMatch = updateOnMatch
+      end
+    end
+
+    # {urn:ws.rsys.com}mergeTableRecordsWithPKResponse
+    class MergeTableRecordsWithPKResponse
+      @@schema_type = "mergeTableRecordsWithPKResponse"
+      @@schema_ns = "urn:ws.rsys.com"
+      @@schema_qualified = "true"
+      @@schema_element = [["result", "MergeResult"]]
+
+      attr_accessor :result
+
+      def initialize(result = nil)
+        @result = result
+      end
+    end
+
+
     # {urn:ws.rsys.com}mergeTableRecordsResponse
     #   result - MergeResult
     class MergeTableRecordsResponse

--- a/lib/stub/defaultDriver.rb
+++ b/lib/stub/defaultDriver.rb
@@ -272,6 +272,13 @@ class ResponsysWS < ::SOAP::RPC::Driver
         :faults => {"TableFault_"=>{:ns=>"urn:ws.rsys.com", :use=>"literal", :namespace=>nil, :encodingstyle=>"document", :name=>"TableFault"}, "UnexpectedErrorFault_"=>{:ns=>"urn:ws.rsys.com", :use=>"literal", :namespace=>nil, :encodingstyle=>"document", :name=>"UnexpectedErrorFault"}} }
     ],
     [ "",
+      "mergeTableRecordsWithPK",
+      [ ["in", "parameters", ["::SOAP::SOAPElement", "urn:ws.rsys.com", "mergeTableRecordsWithPK"], true],
+        ["out", "parameters", ["::SOAP::SOAPElement", "urn:ws.rsys.com", "mergeTableRecordsWithPKResponse"], true] ],
+      { :request_style =>  :document, :request_use =>  :literal,
+        :response_style => :document, :response_use => :literal }
+    ],
+    [ "",
       "retrieveTableRecords",
       [ ["in", "parameters", ["::SOAP::SOAPElement", "urn:ws.rsys.com", "retrieveTableRecords"]],
         ["out", "parameters", ["::SOAP::SOAPElement", "urn:ws.rsys.com", "retrieveTableRecordsResponse"]] ],

--- a/lib/stub/defaultMappingRegistry.rb
+++ b/lib/stub/defaultMappingRegistry.rb
@@ -1556,6 +1556,25 @@ module DefaultMappingRegistry
   )
 
   LiteralRegistry.register(
+    :class => SunDawg::Responsys::MergeTableRecordsWithPK,
+    :schema_name => XSD::QName.new(NsWsRsysCom, "mergeTableRecordsWithPK"),
+    :schema_element => [
+      ["table", "SunDawg::Responsys::InteractObject"],
+      ["recordData", "SunDawg::Responsys::RecordData"],
+      ["insertOnNoMatch", "SOAP::SOAPBoolean"],
+      ["updateOnMatch", "SunDawg::Responsys::UpdateOnMatch"]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => SunDawg::Responsys::MergeTableRecordsWithPKResponse,
+    :schema_name => XSD::QName.new(NsWsRsysCom, "mergeTableRecordsWithPKResponse"),
+    :schema_element => [
+      ["result", "SunDawg::Responsys::MergeResult"]
+    ]
+  )
+
+  LiteralRegistry.register(
     :class => SunDawg::Responsys::RetrieveTableRecords,
     :schema_name => XSD::QName.new(NsWsRsysCom, "retrieveTableRecords"),
     :schema_element => [

--- a/test/member_test.rb
+++ b/test/member_test.rb
@@ -130,7 +130,7 @@ class MemberTest < Test::Unit::TestCase
     SunDawg::Responsys::Member.extension_fields = {:file_a => [:foo], :file_b => [:bar]}
     member = SunDawg::Responsys::Member.new
     member.attributes = {:foo => "value_1", :bar => "value_2", :customer_id => 123}
-    SunDawg::Responsys::Member.expects(:build_csv_file).times(3)
+    SunDawg::Responsys::Member.expects(:build_csv_file).times(2)
     SunDawg::Responsys::Member.to_csv_extension_files([member], "/tmp", :headers => true, :access => "w")
   end
 

--- a/test/responsys_client_integration_test.rb
+++ b/test/responsys_client_integration_test.rb
@@ -6,11 +6,13 @@ class ResponsysClientIntegrationTest < Test::Unit::TestCase
   CAMPAIGN_NAME = "GemCampaignEmail"
   CAMPAIGN_TRANSACTION_NAME = "GemTransactionalEmail"
   LIST_NAME = "GemList"
+
   EMAIL = "gem.test@responsys.client.gem.com"
-  INTEGRATION = true
+  CONFIG_FILE_PATH = "test/config.yml"
 
   def setup
-    config = YAML.load_file("test/config.yml")
+    raise "Missing test/config.yml.  See test/config.yml.sample" unless File.exist?(CONFIG_FILE_PATH)
+    config = YAML.load_file(CONFIG_FILE_PATH)
     @username = config["username"]
     @password = config["password"]
     @file_handle = File.open('/tmp/wiredump', 'w')
@@ -63,6 +65,21 @@ class ResponsysClientIntegrationTest < Test::Unit::TestCase
       assert response.result
       results = @client.list_folders
       assert results.map { |i| i.name }.include? folder_name
+    end
+
+    # This assumes you have a supplemental table called gem_jpj in the Test_Gem list with this schema:
+    # JPJ_1 Text Field (Primary Key)
+    # JPJ_2 Text Field
+    def test_save_supplemental_table_with_pk
+      rando = rand(100)
+      member = {
+        'JPJ_1' => "I am a donkey",
+        'JPJ_2' => "But I love you #{rando}"
+      }
+      response = @client.save_supplemental_table_with_pk(FOLDER_NAME, 'gem_jpj', [member])
+      result = response.result
+      assert_equal 1, result.totalCount
+      assert_equal '', result.errorMessage
     end
 
     def test_save_members
@@ -144,7 +161,7 @@ class ResponsysClientIntegrationTest < Test::Unit::TestCase
       begin
         response = @client.launch_campaign FOLDER_NAME, CAMPAIGN_NAME
         assert response.result 
-      rescue CampaignFault => e
+      rescue SunDawg::Responsys::CampaignFault => e
         # Responsys does not allow campaigns to be launched less than 15 minute attempts
         assert_equal "Launch attempt failed: A campaign cannot be launched more than once per 15 minutes.", e.exception_message
       end

--- a/test/responsys_client_test.rb
+++ b/test/responsys_client_test.rb
@@ -54,7 +54,8 @@ class ResponsysClientTest < Test::Unit::TestCase
 
     ws = stub(:login => stub(:result => stub(:sessionId => 'session ID')),
               :logout => true,
-              :headerhandler => stub(:add))
+              :headerhandler => stub(:add),
+              :options => {})
     ResponsysWS.stubs(:new).returns(ws)
 
     ws.expects(:mergeListMembers).with do |mlm|
@@ -67,7 +68,8 @@ class ResponsysClientTest < Test::Unit::TestCase
   def test_trigger_campaign_removes_illegal_xml_characters
     ws = stub(:login => stub(:result => stub(:sessionId => 'session ID')),
               :logout => true,
-              :headerhandler => stub(:add))
+              :headerhandler => stub(:add),
+              :options => {})
     ResponsysWS.stubs(:new).returns(ws)
 
     ws.expects(:triggerCampaignMessage).with do |tcm|
@@ -80,7 +82,8 @@ class ResponsysClientTest < Test::Unit::TestCase
   def test_trigger_batch_campaign
     ws = stub(:login => stub(:result => stub(:sessionId => 'session ID')),
               :logout => true,
-              :headerhandler => stub(:add))
+              :headerhandler => stub(:add),
+              :options => {})
     ResponsysWS.stubs(:new).returns(ws)
 
     recipients = {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,4 +2,4 @@ require 'test/unit'
 require 'rubygems'
 require 'mocha'
 
-INTEGRATION = false unless defined?(INTEGRATION)
+INTEGRATION = ENV['INTEGRATION'] unless defined?(INTEGRATION)


### PR DESCRIPTION
We are using the version that inserts or updates based on a primary key

SunDawg::Responsys::ResponsysClient#save_supplemental_table_with_pk(folder_name, list_name, members)

Also
- don't run integration tests by default.  To run with integration tests: INTEGRATION=true rake
- don't generate members.csv. We have a separate mechanism for synching responsys contact lists
